### PR TITLE
Update schema for filefort

### DIFF
--- a/resources/v1/schema/spidamin/asset/README.md
+++ b/resources/v1/schema/spidamin/asset/README.md
@@ -6,6 +6,7 @@ Asset JSON Schema's and Interfaces
 1. asset.json - is used for basic getting of stations and assets based on id, bounding box, and company id's
 2. asset_creation.json - the interface to create assets in a service.  This is for generally for adding and removing from the back end services.
 3. asset_search.json - the interface for finding assets based on more complex queries than given in the basic asset interface.
+4. asset_file.json - the interface for retrieving asset attachments
 
 ### Schemas
 
@@ -15,3 +16,4 @@ Asset JSON Schema's and Interfaces
 4. find_params.schema - an object used for searching in the asset_search service.
 5. station.schema - a set of assets with some common geometry
 6. stations.schema - a set of stations returned from various services with a combined geometry.
+7. attachment.schema - an asset attachment

--- a/resources/v1/schema/spidamin/asset/asset.schema
+++ b/resources/v1/schema/spidamin/asset/asset.schema
@@ -25,7 +25,7 @@
     "assetType": {
       "id": "assetType",
       "type": "string",
-      "enum": ["POLE", "NJUNS", "ANALYSIS"]
+      "enum": ["POLE", "NJUNS", "ANALYSIS","PHOTO","FILE"]
     },
     "assetAttachments": {
       "id": "assetAttachments",

--- a/resources/v1/schema/spidamin/asset/interfaces/asset_file.json
+++ b/resources/v1/schema/spidamin/asset/interfaces/asset_file.json
@@ -1,0 +1,56 @@
+{
+    "id": "asset_file_service",
+    "description": "Manage Asset Files",
+    "getName": {
+        "description": "Get name of this service.",
+        "returns": "string"
+    },
+    "getVersionCount": {
+        "description": "Get version count of attachment with uuid.",
+        "returns": "number",
+        "params": [
+            {
+                "type": "string",
+                "name": "uuid",
+                "required": true,
+                "description": "UUID of attachment"
+            }
+        ]
+    },
+    "getFile": {
+        "description": "Get path for attachment with uuid",
+        "returns": "string",
+        "params": [
+            {
+                "type": "string",
+                "name": "uuid",
+                "required": true,
+                "description": "UUID of attachment"
+            },
+            {
+                "type": "number",
+                "name": "offset",
+                "required": false,
+                "description": "Offset of file, defaults to 0"
+            }
+        ]
+    },
+    "getBytes": {
+        "description": "Get base64 encoded bytes for attachment with uuid",
+        "returns": "string",
+        "params": [
+            {
+                "type": "string",
+                "name": "uuid",
+                "required": true,
+                "description": "UUID of attachment"
+            },
+            {
+                "type": "number",
+                "name": "offset",
+                "required": false,
+                "description": "Offset of file, defaults to 0"
+            }
+        ]
+    }
+}

--- a/resources/v1/schema/spidamin/asset/station.schema
+++ b/resources/v1/schema/spidamin/asset/station.schema
@@ -28,7 +28,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["POLE", "NJUNS", "ANALYSIS"]
+        "enum": ["POLE", "NJUNS", "ANALYSIS","FILE","PHOTO"]
       }
     },
     "geometry": {

--- a/src/test/groovy/com/spidasoftware/schema/validation/ServiceSchemaTest.groovy
+++ b/src/test/groovy/com/spidasoftware/schema/validation/ServiceSchemaTest.groovy
@@ -113,7 +113,19 @@ class ServiceSchemaTest extends GroovyTestCase {
 		instance.each{k,v->
 			if(k!="id" && k!="description"){
 				report = schema.validate(JsonLoader.fromString(JsonOutput.toJson(v)))
-				log.debug report
+				report.each{
+					log.info "${this.class} using file: "+it.toString()
+				}
+				assertTrue "${k} should be valid against a schema", report.isSuccess()		
+			}
+		}
+	}
+	
+	void testAssetFileMethodsAgainstServiceMethod() {
+		def instance = slurper.parseText(new File("resources/v1/schema/spidamin/asset/interfaces/asset_file.json").text)
+		instance.each{k,v->
+			if(k!="id" && k!="description"){
+				report = schema.validate(JsonLoader.fromString(JsonOutput.toJson(v)))
 				report.each{
 					log.info "${this.class} using file: "+it.toString()
 				}


### PR DESCRIPTION
## Update Asset Creation Schema for Filefort

There are 3 methods in the old HttpInvoker `AssetCreationService` that are not in the current API.  They are:
1. `getVersionCount` -- to get the number of versions of an attachment based on uuid
2. `getFile` -- get the file associated with an attachment (in the JSON version this will return just the path to the file)
3. `getBytes` -- get the byte content of an attachment

I have created a new interface asset_file.json for these.

Additionally there are 2 asset types "FILE" and "PHOTO" that are used in file fort that are not included in the schema.  I have added these.
