### PR TITLE
Resolve naming collision with job status response definition

### DIFF
--- a/resources/schema/spidacalc/cee/job-status-response.schema
+++ b/resources/schema/spidacalc/cee/job-status-response.schema
@@ -1,5 +1,5 @@
 {
-  "id": "#/spidacalc/cee/job-action-response.schema",
+  "id": "#/spidacalc/cee/job-status-response.schema",
   "description": "The response from a job action (add,update,remove,validate)",
   "type": "object",
   "required": [


### PR DESCRIPTION
`job-status-response.schema` had an incorrect id. This is just a simple one liner, changing it from `"#/spidacalc/cee/job-action-response.schema"` to `""#/spidacalc/cee/job-status-response.schema"`.