### PR TITLE
upgrade ant [#184494538]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,8 +80,8 @@ releaseNotes {
 dependencies {
 	compile 'commons-codec:commons-codec:1.10'
 	compile 'commons-lang:commons-lang:2.6'
-	compile group: 'org.apache.ant', name: 'ant', version: '1.9.4'
-	compile group: 'org.apache.ant', name: 'ant-launcher', version: '1.9.4'
+	compile group: 'org.apache.ant', name: 'ant', version: '1.9.16'
+	compile group: 'org.apache.ant', name: 'ant-launcher', version: '1.9.16'
 	compile group: 'org.codehaus.groovy', name: 'groovy-all', version:'2.4.15'
 	compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.11'
 	compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'


### PR DESCRIPTION
This updates ant to the latest 1.9.x version.  We cannot use 1.10.x as it requires Java 8 and so is not compatible with Studio 20.2.