### PR TITLE
Update sided pole properties [AB#1687185]

### DIFF
--- a/resources/schema/spidacalc/client/pole.schema
+++ b/resources/schema/spidacalc/client/pole.schema
@@ -54,10 +54,15 @@
       "type": "string"
     },
     "taper": {
+      "description": "Taper of the pole. Only for ROUND poles",
+      "type": "number"
+    },
+    "taperStopDistance": {
+      "description": "Distance tapering stops from the butt of the pole",
       "type": "number"
     },
     "wallThickness": {
-      "description":"Thinkness of the material in the pole, solid if not provided.",
+      "description":"Thickness of the material in the pole, solid if not provided.",
       "$ref": "../../general/measurable.schema"
     },
     "aliases": {
@@ -166,7 +171,8 @@
             "anyOf": [
               { "required": [ "maximumGroundLineMoment" ] },
               { "required": [ "longitudinalModulusOfRupture" ] },
-              { "required": [ "transverseModulusOfRupture" ] }
+              { "required": [ "transverseModulusOfRupture" ] },
+              { "required": [ "taperStopDistance" ] }
             ]
           }
         },
@@ -187,7 +193,8 @@
             "anyOf": [
               { "required": [ "maximumAllowableStress" ] },
               { "required": [ "longitudinalModulusOfRupture" ] },
-              { "required": [ "transverseModulusOfRupture" ] }
+              { "required": [ "transverseModulusOfRupture" ] },
+              { "required": [ "taperStopDistance" ] }
             ]
           }
         },
@@ -201,7 +208,7 @@
               "enum": [ "WOOD" ]
             }
           },
-          "required": [ "longitudinalModulusOfRupture", "transverseModulusOfRupture" ],
+          "required": [ "longitudinalModulusOfRupture", "transverseModulusOfRupture", "taperStopDistance" ],
           "not": {
             "anyOf": [
               { "required": [ "maximumAllowableStress" ] },
@@ -248,6 +255,9 @@
                 }
               }
             ]
+          },
+          "not": {
+            "required": [ "taperStopDistance" ]
           },
           "oneOf": [
             {

--- a/resources/schema/spidacalc/client/pole.schema
+++ b/resources/schema/spidacalc/client/pole.schema
@@ -319,9 +319,11 @@
           },
           "required": [ "tipWidth", "tipDepth", "baseWidth", "baseDepth" ],
           "not": {
-            { "required": [ "numberOfSides" ] },
-            { "required": [ "taper" ] },
-            { "required": [ "ptc" ] }
+            "anyOf": [
+              { "required": [ "numberOfSides" ] },
+              { "required": [ "taper" ] },
+              { "required": [ "ptc" ] }
+            ]
           }
         },
         {

--- a/resources/schema/spidacalc/client/pole.schema
+++ b/resources/schema/spidacalc/client/pole.schema
@@ -9,10 +9,8 @@
     "materialCategory",
     "modulus",
     "poissonRatio",
-    "ptc",
     "shape",
     "species",
-    "taper",
     "settingType"
   ],
   "properties": {
@@ -106,10 +104,10 @@
     "baseDepth": {
       "$ref": "../../general/measurable.schema"
     },
-    "maximumLongitudinalMoment": {
+    "longitudinalModulusOfRupture": {
       "$ref": "../../general/measurable.schema"
     },
-    "maximumTransverseMoment": {
+    "transverseModulusOfRupture": {
       "$ref": "../../general/measurable.schema"
     }
   },
@@ -152,33 +150,127 @@
     {
       "oneOf": [
         {
+          "description": "Sided steel poles can only have allowable stress",
+          "properties": {
+            "shape": {
+              "not": {
+                "enum": [ "ROUND" ]
+              }
+            },
+            "materialCategory": {
+              "enum": [ "METAL" ]
+            }
+          },
           "required": [ "maximumAllowableStress" ],
           "not": {
             "anyOf": [
               { "required": [ "maximumGroundLineMoment" ] },
-              { "required": [ "maximumLongitudinalMoment" ] },
-              { "required": [ "maximumTransverseMoment" ] }
+              { "required": [ "longitudinalModulusOfRupture" ] },
+              { "required": [ "transverseModulusOfRupture" ] }
             ]
           }
         },
         {
+          "description": "Sided concrete poles can only have allowable moment",
+          "properties": {
+            "shape": {
+              "not": {
+                "enum": [ "ROUND" ]
+              }
+            },
+            "materialCategory": {
+              "enum": [ "REINFORCED_CONCRETE", "PRESTRESSED_CONCRETE" ]
+            }
+          },
           "required": [ "maximumGroundLineMoment" ],
           "not": {
             "anyOf": [
               { "required": [ "maximumAllowableStress" ] },
-              { "required": [ "maximumLongitudinalMoment" ] },
-              { "required": [ "maximumTransverseMoment" ] }
+              { "required": [ "longitudinalModulusOfRupture" ] },
+              { "required": [ "transverseModulusOfRupture" ] }
             ]
           }
         },
         {
-          "required": [ "maximumLongitudinalMoment", "maximumTransverseMoment" ],
+          "description": "Wood square/rectangular poles can only have longitudinal/transverse modulus of rupture",
+          "properties": {
+            "shape": {
+              "enum": [ "SQUARE", "RECTANGLE" ]
+            },
+            "materialCategory": {
+              "enum": [ "WOOD" ]
+            }
+          },
+          "required": [ "longitudinalModulusOfRupture", "transverseModulusOfRupture" ],
           "not": {
             "anyOf": [
               { "required": [ "maximumAllowableStress" ] },
               { "required": [ "maximumGroundLineMoment" ] }
             ]
           }
+        },
+        {
+          "description": "All other combinations can have either allowable stress or moment",
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "shape": {
+                    "not": {
+                      "enum": [ "ROUND" ]
+                    }
+                  },
+                  "materialCategory": {
+                    "enum": [ "METAL" ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "shape": {
+                    "not": {
+                      "enum": [ "ROUND" ]
+                    }
+                  },
+                  "materialCategory": {
+                    "enum": [ "REINFORCED_CONCRETE", "PRESTRESSED_CONCRETE" ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "shape": {
+                    "enum": [ "SQUARE", "RECTANGLE" ]
+                  },
+                  "materialCategory": {
+                    "enum": [ "WOOD" ]
+                  }
+                }
+              }
+            ]
+          },
+          "oneOf": [
+            {
+              "required": [ "maximumAllowableStress" ],
+              "not": {
+                "anyOf": [
+                  { "required": [ "maximumGroundLineMoment" ] },
+                  { "required": [ "longitudinalModulusOfRupture" ] },
+                  { "required": [ "transverseModulusOfRupture" ] }
+                ]
+              }
+            },
+            {
+              "required": [ "maximumGroundLineMoment" ],
+              "not": {
+                "anyOf": [
+                  { "required": [ "maximumAllowableStress" ] },
+                  { "required": [ "longitudinalModulusOfRupture" ] },
+                  { "required": [ "transverseModulusOfRupture" ] }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -196,8 +288,8 @@
               { "required": [ "numberOfSides" ] },
               { "required": [ "tipDepth" ] },
               { "required": [ "baseDepth" ] },
-              { "required": [ "maximumLongitudinalMoment" ] },
-              { "required": [ "maximumTransverseMoment" ] }
+              { "required": [ "taper" ] },
+              { "required": [ "ptc" ] }
             ]
           }
         },
@@ -212,8 +304,10 @@
             "anyOf": [
               { "required": [ "tipDepth" ] },
               { "required": [ "baseDepth" ] },
-              { "required": [ "maximumLongitudinalMoment" ] },
-              { "required": [ "maximumTransverseMoment" ] }
+              { "required": [ "longitudinalModulusOfRupture" ] },
+              { "required": [ "transverseModulusOfRupture" ] },
+              { "required": [ "taper" ] },
+              { "required": [ "ptc" ] }
             ]
           }
         },
@@ -225,7 +319,9 @@
           },
           "required": [ "tipWidth", "tipDepth", "baseWidth", "baseDepth" ],
           "not": {
-            "required": [ "numberOfSides" ]
+            { "required": [ "numberOfSides" ] },
+            { "required": [ "taper" ] },
+            { "required": [ "ptc" ] }
           }
         },
         {
@@ -234,6 +330,7 @@
               "enum": [ "ROUND" ]
             }
           },
+          "required": [ "taper", "ptc" ],
           "not": {
             "anyOf": [
               { "required": [ "numberOfSides" ] },
@@ -241,8 +338,8 @@
               { "required": [ "tipDepth" ] },
               { "required": [ "baseWidth" ] },
               { "required": [ "baseDepth" ] },
-              { "required": [ "maximumLongitudinalMoment" ] },
-              { "required": [ "maximumTransverseMoment" ] }
+              { "required": [ "longitudinalModulusOfRupture" ] },
+              { "required": [ "transverseModulusOfRupture" ] }
             ]
           }
         }


### PR DESCRIPTION
- wood square/rectangle poles must have `longitudinalModulusOfRupture`, `transverseModulusOfRupture`, and `taperStopDistance`. 
- sided steel poles must have `maximumAllowableStress`.
- sided concrete poles must have `maximumGroundLineMoment`.
- sided poles cannot have `taper` or `ptc`
